### PR TITLE
Optimize targeting with pre-filtered unit sets

### DIFF
--- a/src/entities/units.py
+++ b/src/entities/units.py
@@ -34,7 +34,7 @@ from components.position import Position
 from components.animation import AnimationState, AnimationType
 from components.sprite_sheet import SpriteSheet
 from components.status_effect import CrusaderBannerBearerEmpowered, Fleeing, Healing, DamageOverTime, StatusEffects, ZombieInfection, CrusaderBannerBearerMovementSpeedBuff, CrusaderBannerBearerAbilitySpeedBuff
-from target_strategy import ByCurrentHealth, ByDistance, ByMissingHealth, ConditionPenalty, TargetStrategy, WeightedRanking
+from target_strategy import ByCurrentHealth, ByDistance, ByMissingHealth, ConditionPenalty, TargetStrategy, WeightedRanking, create_enemy_targeting_strategy, create_friendly_targeting_strategy, create_any_living_targeting_strategy
 from components.destination import Destination
 from components.team import Team, TeamType
 from components.unit_state import State, UnitState
@@ -344,11 +344,12 @@ def create_core_archer(
         corruption_powers=corruption_powers,
         tier=tier
     )
-    targetting_strategy = TargetStrategy(
+    targetting_strategy = create_enemy_targeting_strategy(
+        team=team,
         rankings=[
             ByDistance(entity=entity, y_bias=2, ascending=True),
         ],
-        unit_condition=All([OnTeam(team=team.other()), Alive()])
+        grounded_only=False
     )
     esper.add_component(
         entity,

--- a/src/processors/targetting_processor.py
+++ b/src/processors/targetting_processor.py
@@ -6,21 +6,45 @@ from components.ability import Abilities
 from components.destination import Destination
 from components.instant_ability import InstantAbilities
 from components.unit_state import State, UnitState
+from unit_sets import unit_set_manager
 
 
 class TargettingProcessor(esper.Processor):
     """Processor responsible for targetting."""
 
     def process(self, dt: float):
+        # Reset the unit set manager for this frame
+        unit_set_manager.reset_frame()
+        
+        # Collect all target strategies and request their unit sets
         target_strategies = set()
         for ent, (unit_state, destination) in esper.get_components(UnitState, Destination):
-            target_strategies.add((ent, unit_state.state, destination.target_strategy))
+            target_strategy = destination.target_strategy
+            target_strategies.add((ent, unit_state.state, target_strategy))
+            # Request unit set if the strategy uses one
+            if target_strategy.unit_set_type is not None:
+                unit_set_manager.request_unit_set(target_strategy.unit_set_type)
+                
         for ent, (unit_state, instant_abilities) in esper.get_components(UnitState, InstantAbilities):
             for ability in instant_abilities.abilities:
-                target_strategies.add((ent, unit_state.state, ability.target_strategy))
+                target_strategy = ability.target_strategy
+                target_strategies.add((ent, unit_state.state, target_strategy))
+                # Request unit set if the strategy uses one
+                if target_strategy.unit_set_type is not None:
+                    unit_set_manager.request_unit_set(target_strategy.unit_set_type)
+                    
         for ent, (unit_state, abilities) in esper.get_components(UnitState, Abilities):
             for ability in abilities.abilities:
-                target_strategies.add((ent, unit_state.state, ability.target_strategy))
+                target_strategy = ability.target_strategy
+                target_strategies.add((ent, unit_state.state, target_strategy))
+                # Request unit set if the strategy uses one
+                if target_strategy.unit_set_type is not None:
+                    unit_set_manager.request_unit_set(target_strategy.unit_set_type)
+        
+        # Compute all requested unit sets once
+        unit_set_manager.compute_sets()
+        
+        # Now process all target strategies
         for ent, state, target_strategy in target_strategies:
             # Consider new targets
             if state == State.IDLE or state == State.PURSUING:

--- a/src/unit_sets.py
+++ b/src/unit_sets.py
@@ -1,0 +1,145 @@
+"""Pre-filtered unit sets for efficient targeting."""
+
+from enum import Enum, auto
+from typing import Dict, Set
+import esper
+
+from components.position import Position
+from components.team import Team, TeamType
+from components.unit_state import State, UnitState
+from components.airborne import Airborne
+
+
+class UnitSetType(Enum):
+    """Enum for different pre-filtered unit sets."""
+    
+    # Living units by team
+    TEAM1_LIVING = auto()
+    TEAM2_LIVING = auto()
+    
+    # Living grounded units by team
+    TEAM1_LIVING_GROUNDED = auto()
+    TEAM2_LIVING_GROUNDED = auto()
+    
+    # All living units (any team)
+    ALL_LIVING = auto()
+    
+    # All living grounded units (any team)
+    ALL_LIVING_GROUNDED = auto()
+    
+    # All units with positions (baseline)
+    ALL_POSITIONED = auto()
+
+
+class UnitSetManager:
+    """Manages pre-filtered unit sets for efficient targeting."""
+    
+    def __init__(self):
+        self._unit_sets: Dict[UnitSetType, Set[int]] = {}
+        self._sets_needed: Set[UnitSetType] = set()
+        self._computed_this_frame = False
+    
+    def request_unit_set(self, set_type: UnitSetType) -> None:
+        """Request that a unit set be computed this frame."""
+        self._sets_needed.add(set_type)
+    
+    def get_unit_set(self, set_type: UnitSetType) -> Set[int]:
+        """Get a pre-filtered unit set. Must call compute_sets() first."""
+        if not self._computed_this_frame:
+            raise RuntimeError("Must call compute_sets() before getting unit sets")
+        
+        if set_type not in self._unit_sets:
+            return set()
+        
+        return self._unit_sets[set_type]
+    
+    def compute_sets(self) -> None:
+        """Compute all requested unit sets for this frame."""
+        self._unit_sets.clear()
+        
+        if not self._sets_needed:
+            self._computed_this_frame = True
+            return
+        
+        # Start with all positioned entities as base set
+        all_positioned = set()
+        for entity, (_,) in esper.get_components(Position):
+            all_positioned.add(entity)
+        
+        # If we need the base set, store it
+        if UnitSetType.ALL_POSITIONED in self._sets_needed:
+            self._unit_sets[UnitSetType.ALL_POSITIONED] = all_positioned.copy()
+        
+        # Filter to living units
+        living_units = set()
+        team1_living = set()
+        team2_living = set()
+        
+        for entity in all_positioned:
+            unit_state = esper.try_component(entity, UnitState)
+            if unit_state is None or unit_state.state == State.DEAD:
+                continue
+            
+            living_units.add(entity)
+            
+            # Categorize by team
+            team = esper.try_component(entity, Team)
+            if team is not None:
+                if team.type == TeamType.TEAM1:
+                    team1_living.add(entity)
+                elif team.type == TeamType.TEAM2:
+                    team2_living.add(entity)
+        
+        # Store living sets if needed
+        if UnitSetType.ALL_LIVING in self._sets_needed:
+            self._unit_sets[UnitSetType.ALL_LIVING] = living_units.copy()
+        if UnitSetType.TEAM1_LIVING in self._sets_needed:
+            self._unit_sets[UnitSetType.TEAM1_LIVING] = team1_living.copy()
+        if UnitSetType.TEAM2_LIVING in self._sets_needed:
+            self._unit_sets[UnitSetType.TEAM2_LIVING] = team2_living.copy()
+        
+        # Filter to grounded units if needed
+        grounded_sets_needed = {
+            UnitSetType.ALL_LIVING_GROUNDED,
+            UnitSetType.TEAM1_LIVING_GROUNDED,
+            UnitSetType.TEAM2_LIVING_GROUNDED
+        }
+        
+        if grounded_sets_needed & self._sets_needed:
+            living_grounded = set()
+            team1_living_grounded = set()
+            team2_living_grounded = set()
+            
+            for entity in living_units:
+                # Check if grounded (not airborne)
+                if esper.has_component(entity, Airborne):
+                    continue
+                
+                living_grounded.add(entity)
+                
+                # Categorize by team
+                team = esper.try_component(entity, Team)
+                if team is not None:
+                    if team.type == TeamType.TEAM1:
+                        team1_living_grounded.add(entity)
+                    elif team.type == TeamType.TEAM2:
+                        team2_living_grounded.add(entity)
+            
+            # Store grounded sets if needed
+            if UnitSetType.ALL_LIVING_GROUNDED in self._sets_needed:
+                self._unit_sets[UnitSetType.ALL_LIVING_GROUNDED] = living_grounded.copy()
+            if UnitSetType.TEAM1_LIVING_GROUNDED in self._sets_needed:
+                self._unit_sets[UnitSetType.TEAM1_LIVING_GROUNDED] = team1_living_grounded.copy()
+            if UnitSetType.TEAM2_LIVING_GROUNDED in self._sets_needed:
+                self._unit_sets[UnitSetType.TEAM2_LIVING_GROUNDED] = team2_living_grounded.copy()
+        
+        self._computed_this_frame = True
+    
+    def reset_frame(self) -> None:
+        """Reset for the next frame."""
+        self._sets_needed.clear()
+        self._computed_this_frame = False
+
+
+# Global instance for the unit set manager
+unit_set_manager = UnitSetManager()


### PR DESCRIPTION
Implement pre-filtered unit sets to optimize targeting performance by reducing redundant entity filtering.

The existing targeting system iterated through all entities with positions for each targeting strategy, leading to redundant filtering for common conditions (e.g., "enemy living grounded units"). This PR introduces a `UnitSetManager` that pre-computes and caches these common unit sets once per frame, allowing targeting strategies to filter from a much smaller, already-filtered collection, significantly improving performance.

---

[Open in Web](https://cursor.com/agents?id=bc-734da259-afb2-44bb-a502-7ac4378093e5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-734da259-afb2-44bb-a502-7ac4378093e5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)